### PR TITLE
New arguments for specific patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ _Note_: Apple CPU identifier must be `<0F01>` for 8 core CPUs or higher and `<06
 - `-revbeta` (or `-lilubetaall`) to enable on macOS older than 10.8 or newer than 12
 - `-revproc` to enable verbose process logging (in DEBUG builds)
 - `-revnopatch` to disable patching for userspace processes
+- `-revnomemmgmtpatch` to disable patching of PCI/memory UI only
+- `-revnocpunamepatch` to disable patching of cpu renaming only
 - `revcpu=value` to enable (`1`, non-Intel default)/disable (`0`, Intel default) CPU brand string patching.
 - `revcpuname=value` custom CPU brand string (max 48 characters, 20 or less recommended, taken from CPUID otherwise)
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,11 @@ _Note_: Apple CPU identifier must be `<0F01>` for 8 core CPUs or higher and `<06
 - `-revdbg` (or `-liludbgall`) to enable verbose logging (in DEBUG builds)
 - `-revbeta` (or `-lilubetaall`) to enable on macOS older than 10.8 or newer than 12
 - `-revproc` to enable verbose process logging (in DEBUG builds)
-- `-revnopatch` to disable patching for userspace processes
-- `-revnomemmgmtpatch` to disable patching of PCI/memory UI only
-- `-revnocpunamepatch` to disable patching of cpu renaming only
+- `revnopatch=value` to disable patching for userspace processes of Memory/PCI UI and/or CPU renaming or no patching will happen. Accepted values are `all`, `mempci`, `cpuname`, `none` Defaults to `none`.
 - `revcpu=value` to enable (`1`, non-Intel default)/disable (`0`, Intel default) CPU brand string patching.
 - `revcpuname=value` custom CPU brand string (max 48 characters, 20 or less recommended, taken from CPUID otherwise)
 
-_Note_: `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revcpu` and `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revcpuname` NVRAM variables work the same as the boot arguments, but have lower priority.
+_Note_: `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revnopatch`, `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revcpu` and `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revcpuname` NVRAM variables work the same as the boot arguments, but have lower priority.
 
 #### Credits
 - [Apple](https://www.apple.com) for macOS  

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -226,7 +226,7 @@ struct RestrictEventsPolicy {
 	 * Retrieve which system UI is to be disabled - all, mempci, cpuname, none (default)
 	 */
 	static void processDisableUIPatch() {
-    uint32_t duip[32] {};
+		char duip[128] {};
 		if (PE_parse_boot_argn("revnopatch", duip, sizeof(duip))) {
 			DBGLOG("rev", "read revnopatch from boot-args");
 		} else if (readNvramVariable(NVRAM_PREFIX(LILU_VENDOR_GUID, "revnopatch"), u"revnopatch", &EfiRuntimeServices::LiluVendorGuid, duip, sizeof(duip))) {

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -29,6 +29,9 @@ static const char *bootargBeta[] {
 	"-revbeta"
 };
 
+static bool disableMemoryManagementPatching;
+static bool disableCpuNamePatching;
+static bool disableAllPatching;
 static bool verboseProcessLogging;
 static mach_vm_address_t orgCsValidateFunc;
 
@@ -337,9 +340,12 @@ PluginConfiguration ADDPR(config) {
 	[]() {
 		DBGLOG("rev", "restriction policy plugin loaded");
 		verboseProcessLogging = checkKernelArgument("-revproc");
+		disableMemoryManagementPatching = checkKernelArgument("-revnomemmgmtpatch");
+		disableCpuNamePatching = checkKernelArgument("-revnocpunamepatch");
+		disableAllPatching = checkKernelArgument("-revnopatch");
 		restrictEventsPolicy.policy.registerPolicy();
 
-		if (!(checkKernelArgument("-revnomemmgmtpatch") || checkKernelArgument("-revnopatch")) && (lilu.getRunMode() & LiluAPI::RunningNormal) != 0) {
+		if (!(disableMemoryManagementPatching || disableAllPatching) && (lilu.getRunMode() & LiluAPI::RunningNormal) != 0) {
 			auto di = BaseDeviceInfo::get();
 			// Rename existing values to invalid ones to avoid matching.
 			if (strcmp(di.modelIdentifier, "MacPro7,1") == 0) {
@@ -355,7 +361,7 @@ PluginConfiguration ADDPR(config) {
 			}
     }
 
-    if (!(checkKernelArgument("-revnocpunamepatch") || checkKernelArgument("-revnopatch")) && (lilu.getRunMode() & LiluAPI::RunningNormal) != 0) {
+    if (!(disableCpuNamePatching || disableAllPatching) && (lilu.getRunMode() & LiluAPI::RunningNormal) != 0) {
 			needsCpuNamePatch = RestrictEventsPolicy::needsCpuNamePatch();
 			if (memFindPatch != nullptr || needsCpuNamePatch) {
 				lilu.onPatcherLoadForce([](void *user, KernelPatcher &patcher) {

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -241,13 +241,8 @@ struct RestrictEventsPolicy {
 			disableAllPatching = true;
 		} else if (strcmp(value, "mempci") == 0) {
 			disableMemoryPciManagementPatching = true;
-			disableAllPatching = false;
 		} else if (strcmp(value, "cpuname") == 0) {
 			disableCpuNamePatching = true;
-			disableAllPatching = false;
-		} else {
-			// Apply all UI patches. Treat as 'none'.
-			disableAllPatching = false;
 		}
 
 		DBGLOG("rev", "revnopatch to disable %s", duip);

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -236,13 +236,13 @@ struct RestrictEventsPolicy {
 		char *value = reinterpret_cast<char *>(&duip[0]);
 		value[sizeof(duip) - 1] = '\0';
 
-		if (strncmp(value, "all", 3) == 0) {
+		if (strcmp(value, "all") == 0) {
 			// Disable all UI patches
 			disableAllPatching = true;
-		} else if (strncmp(value, "mempci", 6) == 0) {
+		} else if (strcmp(value, "mempci") == 0) {
 			disableMemoryPciManagementPatching = true;
 			disableAllPatching = false;
-		} else if (strncmp(value, "cpuname", 7) == 0) {
+		} else if (strcmp(value, "cpuname") == 0) {
 			disableCpuNamePatching = true;
 			disableAllPatching = false;
 		} else {

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -371,7 +371,7 @@ PluginConfiguration ADDPR(config) {
 	[]() {
 		DBGLOG("rev", "restriction policy plugin loaded");
 		verboseProcessLogging = checkKernelArgument("-revproc");
-    RestrictEventsPolicy::processDisableUIPatch();
+		RestrictEventsPolicy::processDisableUIPatch();
 		restrictEventsPolicy.policy.registerPolicy();
 
 		if ((lilu.getRunMode() & LiluAPI::RunningNormal) != 0) {

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -339,7 +339,7 @@ PluginConfiguration ADDPR(config) {
 		verboseProcessLogging = checkKernelArgument("-revproc");
 		restrictEventsPolicy.policy.registerPolicy();
 
-		if (!checkKernelArgument("-revnopatch") && (lilu.getRunMode() & LiluAPI::RunningNormal) != 0) {
+		if (!(checkKernelArgument("-revnomemmgmtpatch") || checkKernelArgument("-revnopatch")) && (lilu.getRunMode() & LiluAPI::RunningNormal) != 0) {
 			auto di = BaseDeviceInfo::get();
 			// Rename existing values to invalid ones to avoid matching.
 			if (strcmp(di.modelIdentifier, "MacPro7,1") == 0) {
@@ -353,7 +353,9 @@ PluginConfiguration ADDPR(config) {
 				memFindSize  = sizeof("MacBookAir");
 				DBGLOG("rev", "detected MBA");
 			}
+    }
 
+    if (!(checkKernelArgument("-revnocpunamepatch") || checkKernelArgument("-revnopatch")) && (lilu.getRunMode() & LiluAPI::RunningNormal) != 0) {
 			needsCpuNamePatch = RestrictEventsPolicy::needsCpuNamePatch();
 			if (memFindPatch != nullptr || needsCpuNamePatch) {
 				lilu.onPatcherLoadForce([](void *user, KernelPatcher &patcher) {


### PR DESCRIPTION
Hi,

Personally, on my hackintosh, I only want to enable cpu renaming but still like to display the MacPro7,1 PCI and memory UIs via `-revnomemmgmtpatch`.

I thought that some might like only the PCI and memory UIs thus I support another checking for `-revnocpunamepatch`

Thanks