### PR TITLE
Add support for AssetCache kern.hv_vmm_present spoofing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@ RestrictEvents Changelog
 #### v1.0.6
 - Fixed memory view restrictions for `MacBookAir` and `MacBookPro10` not being correctly disabled
 - Disabled `The disk you inserted was not readable by this computer` message popup
+- Added Content Caching support for systems exposing `kern.hv_vmm_present` via `-revasset`
+- Lowered OS requirement for `-revsbvmm` to macOS 11.3
 
 #### v1.0.5
 - Added macOS 12 software update support with any Mac model via `-revsbvmm`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ _Note_: Apple CPU identifier must be `0x0F01` for 8 core CPUs or higher and `0x0
 - `-revdbg` (or `-liludbgall`) to enable verbose logging (in DEBUG builds)
 - `-revbeta` (or `-lilubetaall`) to enable on macOS older than 10.8 or newer than 12
 - `-revproc` to enable verbose process logging (in DEBUG builds)
-- `-revsbvmm` to force VMM SB model, allowing `x86legacy` SB model on T2 Mac model for macOS 12
+- `-revsbvmm` to force VMM SB model, allowing OTA updates for unsupported models on macOS 11.3 or newer
+- `-revasset` to allow Content Caching when `sysctl kern.hv_vmm_present` returns `1` on macOS 11.3 or newer
 - `revnopatch=value` to disable patching for userspace processes of Memory/PCI UI, CPU renaming, and/or unreadable disk popups or no patching will happen. Accepted values are `all`, `mempci`, `cpuname`, `diskread`, `none` Defaults to `none`.
 - `revcpu=value` to enable (`1`, non-Intel default)/disable (`0`, Intel default) CPU brand string patching.
 - `revcpuname=value` custom CPU brand string (max 48 characters, 20 or less recommended, taken from CPUID otherwise)

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -442,7 +442,9 @@ PluginConfiguration ADDPR(config) {
 			
 			needsCpuNamePatch = !(disableCpuNamePatching || disableAllPatching) == true ? RestrictEventsPolicy::needsCpuNamePatch() : false;
 			needsDiskArbitrationPatch = !(disableDiskArbitrationPatching || disableAllPatching) == true;
-			if (modelFindPatch != nullptr || needsCpuNamePatch || needsDiskArbitrationPatch || (getKernelVersion() >= KernelVersion::Monterey || (getKernelVersion() == KernelVersion::BigSur && getKernelMinorVersion() >= 4))) {
+			if (modelFindPatch != nullptr || needsCpuNamePatch || needsDiskArbitrationPatch ||
+				(getKernelVersion() >= KernelVersion::Monterey ||
+				(getKernelVersion() == KernelVersion::BigSur && getKernelMinorVersion() >= 4))) {
 				lilu.onPatcherLoadForce([](void *user, KernelPatcher &patcher) {
 					if (needsCpuNamePatch) RestrictEventsPolicy::calculatePatchedBrandString();
 					KernelPatcher::RouteRequest csRoute =
@@ -451,7 +453,9 @@ PluginConfiguration ADDPR(config) {
 						KernelPatcher::RouteRequest("_cs_validate_range", RestrictEventsPolicy::csValidateRange, orgCsValidateFunc);
 					if (!patcher.routeMultipleLong(KernelPatcher::KernelID, &csRoute, 1))
 						SYSLOG("rev", "failed to route cs validation pages");
-					if ((getKernelVersion() >= KernelVersion::Monterey || (getKernelVersion() == KernelVersion::BigSur && getKernelMinorVersion() >= 4)) && (checkKernelArgument("-revsbvmm") || checkKernelArgument("-revasset")))
+					if ((getKernelVersion() >= KernelVersion::Monterey ||
+						(getKernelVersion() == KernelVersion::BigSur && getKernelMinorVersion() >= 4)) &&
+						(checkKernelArgument("-revsbvmm") || checkKernelArgument("-revasset")))
 						rerouteHvVmm(patcher);
 				});
 			}

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -392,7 +392,7 @@ struct RestrictEventsPolicy {
 
 static RestrictEventsPolicy restrictEventsPolicy;
 
-void enableSoftwareUpdates(KernelPatcher &patcher);
+void rerouteHvVmm(KernelPatcher &patcher);
 
 PluginConfiguration ADDPR(config) {
 	xStringify(PRODUCT_NAME),
@@ -442,7 +442,7 @@ PluginConfiguration ADDPR(config) {
 			
 			needsCpuNamePatch = !(disableCpuNamePatching || disableAllPatching) == true ? RestrictEventsPolicy::needsCpuNamePatch() : false;
 			needsDiskArbitrationPatch = !(disableDiskArbitrationPatching || disableAllPatching) == true;
-			if (modelFindPatch != nullptr || needsCpuNamePatch || needsDiskArbitrationPatch || getKernelVersion() >= KernelVersion::Monterey) {
+			if (modelFindPatch != nullptr || needsCpuNamePatch || needsDiskArbitrationPatch || (getKernelVersion() >= KernelVersion::Monterey || (getKernelVersion() == KernelVersion::BigSur && getKernelMinorVersion() >= 4))) {
 				lilu.onPatcherLoadForce([](void *user, KernelPatcher &patcher) {
 					if (needsCpuNamePatch) RestrictEventsPolicy::calculatePatchedBrandString();
 					KernelPatcher::RouteRequest csRoute =
@@ -451,8 +451,8 @@ PluginConfiguration ADDPR(config) {
 						KernelPatcher::RouteRequest("_cs_validate_range", RestrictEventsPolicy::csValidateRange, orgCsValidateFunc);
 					if (!patcher.routeMultipleLong(KernelPatcher::KernelID, &csRoute, 1))
 						SYSLOG("rev", "failed to route cs validation pages");
-					if (getKernelVersion() >= KernelVersion::Monterey && checkKernelArgument("-revsbvmm"))
-						enableSoftwareUpdates(patcher);
+					if ((getKernelVersion() >= KernelVersion::Monterey || (getKernelVersion() == KernelVersion::BigSur && getKernelMinorVersion() >= 4)) && (checkKernelArgument("-revsbvmm") || checkKernelArgument("-revasset")))
+						rerouteHvVmm(patcher);
 				});
 			}
 		}

--- a/RestrictEvents/SoftwareUpdate.cpp
+++ b/RestrictEvents/SoftwareUpdate.cpp
@@ -195,16 +195,18 @@ static sysctl_oid *sysctl_by_name(sysctl_oid_list *sysctl_children, const char *
     return nullptr;
 }
 
+static const char revasset_arg = checkKernelArgument("-revasset");
+static const char revsbvmm_arg = checkKernelArgument("-revsbvmm");
 static mach_vm_address_t org_sysctl_vmm_present;
 static int my_sysctl_vmm_present(__unused struct sysctl_oid *oidp, __unused void *arg1, int arg2, struct sysctl_req *req) {
     char procname[64];
     proc_name(proc_pid(req->p), procname, sizeof(procname));
     // SYSLOG("supd", "\n\n\n\nsoftwareupdated vmm_present %d - >>> %s <<<<\n\n\n\n", arg2, procname);
-    if (checkKernelArgument("-revsbvmm") && (strcmp(procname, "softwareupdated") == 0 || strcmp(procname, "com.apple.Mobile") == 0)) {
+    if (revsbvmm_arg && (strcmp(procname, "softwareupdated") == 0 || strcmp(procname, "com.apple.Mobile") == 0)) {
 		int hv_vmm_present_on = 1;
 		return SYSCTL_OUT(req, &hv_vmm_present_on, sizeof(hv_vmm_present_on));
     }
-	else if (checkKernelArgument("-revasset") && (strcmp(procname, "AssetCache") == 0 || strcmp(procname, "AssetCacheManage") == 0)) {
+	else if (revasset_arg && (strncmp(procname, "AssetCache",  strlen("AssetCache")) == 0)) {
 		int hv_vmm_present_off = 0;
 		return SYSCTL_OUT(req, &hv_vmm_present_off, sizeof(hv_vmm_present_off));
 	}


### PR DESCRIPTION
Force `sysctl kern.hv_vmm_present` to return `0` if AssetCache is requesting. 

Changes made:

* New boot-arg for controlling AssetCache spoofing: `-revasset`
* Lower OS requirement of `-revsbvmm` to 20.4.0+ (11.3+)
* Rename `enableSoftwareUpdates` function to `rerouteHvVmm`
* Add argument check to `my_sysctl_vmm_present`