### PR TITLE
Fixed detecting CPU core count on Intel CPU

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 RestrictEvents Changelog
 ========================
+#### v1.0.7
+- Fixed detecting CPU core count on Intel CPU
+
 #### v1.0.6
 - Fixed memory view restrictions for `MacBookAir` and `MacBookPro10` not being correctly disabled
 - Disabled `The disk you inserted was not readable by this computer` message popup

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -16,6 +16,7 @@
 #include "SoftwareUpdate.hpp"
 
 extern "C" {
+#include <i386/cpuid.h>
 #include <i386/pmCPU.h>
 }
 
@@ -245,8 +246,14 @@ struct RestrictEventsPolicy {
 		CPUInfo::getCpuid(0, 0, nullptr, &b, &c, &d);
 		bool isAMD = (b == CPUInfo::signature_AMD_ebx && c == CPUInfo::signature_AMD_ecx && d == CPUInfo::signature_AMD_edx);
 
-		pmKextRegister(PM_DISPATCH_VERSION, NULL, &pmCallbacks);
 		uint32_t cc = 0, pp = 0;
+		if (!isAMD) {
+			cc = cpuid_info()->core_count;
+			DBGLOG("rev", "calculated %u cores from cpuid_info()", cc);
+			return cc;
+		}
+
+		pmKextRegister(PM_DISPATCH_VERSION, NULL, &pmCallbacks);
 		auto pkg = pmCallbacks.GetPkgRoot();
 		while (pkg != nullptr) {
 			auto core = pkg->cores;
@@ -257,7 +264,6 @@ struct RestrictEventsPolicy {
 			DBGLOG("rev", "calculated %u cores in pkg %u amd %d", cc, pp, isAMD);
 			pp++;
 			pkg = pkg->next;
-			if (!isAMD) break;
 		}
 
 		return cc;


### PR DESCRIPTION
## Background
RestricEvents.kext counts cores by tracing [x86_pkgs](https://github.com/apple/darwin-xnu/blob/8f02f2a044b9bb1ad951987ef5bab20ec9486310/osfmk/i386/pmCPU.c#L898-L902) structure, but macOS doesn't seem to use x86_pkgs when setting the processor name in About This Mac. macOS may read other information like [cpuid_info()](https://github.com/apple/darwin-xnu/blob/a1babec6b135d1f35b2590a1990af3c5c5393479/osfmk/i386/cpuid.h#L578).

It's not normally a problem as each method returns the same core count, but it's a problem if x86_pkgs has been modified, for example my [CpuTopologyRebuild.kext](https://github.com/b00t0x/CpuTopologyRebuild).

see also : https://github.com/b00t0x/CpuTopologyRebuild/issues/2

## Changes
This commit changes the logic to use `cpuid_info()->core_count` for getting core count. The original logic using the x86_pkgs seems to be written for AMD environment, and I don't know how this fix affects it, so I don't removed the logic and left it for AMD.

## Samples
### Before
```
maint@Z690M ~ % grep -A1 '<key>revcpuname' /Volumes/USB/EFI/OC/config.plist
				<key>revcpuname</key>
				<string>NAME NAME NAME</string>
maint@Z690M ~ % kextstat | grep RestrictEvents                             
Executing: /usr/bin/kmutil showloaded
No variant specified, falling back to release
   53    0 0                  0xf000     0xf000     as.vit9696.RestrictEvents (1.0.6) 429B25D1-F485-39A6-AA3C-C0B527FB944E <51 9 7 6 3 2 1>
maint@Z690M ~ % sysctl machdep.cpu | grep count                            
machdep.cpu.core_count: 24
machdep.cpu.thread_count: 24
maint@Z690M ~ % grep rev /var/log/Lilu_1.5.9_21.2.txt
RestrictEvents       rev: @ (DBG) restriction policy plugin loaded
RestrictEvents       rev: @ (DBG) revnopatch to disable 
RestrictEvents       rev: @ (DBG) read revcpu override from NVRAM - 1
RestrictEvents       rev: @ (DBG) read revcpuname from NVRAM
RestrictEvents       rev: @ (DBG) requested to patch CPU name to NAME NAME NAME
RestrictEvents       rev: @ (DBG) calculated 16 cores in pkg 0 amd 0
RestrictEvents       rev: @ (DBG) chosen 16-Core Intel Xeon W patch for 16 core CPU
RestrictEvents       rev: @ (DBG) init bsd policy on 21
RestrictEvents       rev: @ (DBG) patched 16-Core Intel Xeon W in AppleSystemInfo
```
<img width="810" alt="Screen Shot 2022-01-18 at 0 57 40" src="https://user-images.githubusercontent.com/2325377/149808578-b501663e-a254-4fc3-913b-3afa670fdc98.png">

### After
```
maint@Z690M ~ % grep -A1 '<key>revcpuname' /Volumes/USB/EFI/OC/config.plist
				<key>revcpuname</key>
				<string>NAME NAME NAME</string>
maint@Z690M ~ % kextstat | grep RestrictEvents                             
Executing: /usr/bin/kmutil showloaded
No variant specified, falling back to release
   53    0 0                  0x14000    0x14000    as.vit9696.RestrictEvents (1.0.7) 1F40922B-BA76-3783-A69F-6B61FBE3C87D <51 9 7 6 3 2 1>
maint@Z690M ~ % sysctl machdep.cpu | grep count                            
machdep.cpu.core_count: 24
machdep.cpu.thread_count: 24
maint@Z690M ~ % grep rev /var/log/Lilu_1.5.9_21.2.txt
RestrictEvents       rev: @ (DBG) restriction policy plugin loaded
RestrictEvents       rev: @ (DBG) revnopatch to disable 
RestrictEvents       rev: @ (DBG) read revcpu override from NVRAM - 1
RestrictEvents       rev: @ (DBG) read revcpuname from NVRAM
RestrictEvents       rev: @ (DBG) requested to patch CPU name to NAME NAME NAME
RestrictEvents       rev: @ (DBG) calculated 24 cores from cpuid_info()
RestrictEvents       rev: @ (DBG) chosen 24-Core Intel Xeon W patch for 24 core CPU
RestrictEvents       rev: @ (DBG) init bsd policy on 21
RestrictEvents       rev: @ (DBG) patched 24-Core Intel Xeon W in AppleSystemInfo
```
<img width="810" alt="Screen Shot 2022-01-18 at 1 02 18" src="https://user-images.githubusercontent.com/2325377/149808667-24f657cb-9bb8-445a-9aee-0efa2d236855.png">

