### PR TITLE
Add support for older versions and enable flexibility

### DIFF
--- a/RestrictEvents.xcodeproj/project.pbxproj
+++ b/RestrictEvents.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		1CF01C901C8CF97F002DCEA3 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		1CF01C921C8CF997002DCEA3 /* Changelog.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Changelog.md; sourceTree = "<group>"; };
 		1CF01C931C8DF02E002DCEA3 /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
+		415F010527AB6C21001F0143 /* vnode_types.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = vnode_types.hpp; sourceTree = "<group>"; };
 		CE405EBA1E49DD7100AA0B3D /* kern_compression.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = kern_compression.hpp; sourceTree = "<group>"; };
 		CE405EBB1E49DD7100AA0B3D /* kern_disasm.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = kern_disasm.hpp; sourceTree = "<group>"; };
 		CE405EBC1E49DD7100AA0B3D /* kern_file.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = kern_file.hpp; sourceTree = "<group>"; };
@@ -145,6 +146,7 @@
 				CE7B69372704BDE600BC8A8A /* SoftwareUpdate.cpp */,
 				CE6717F0278CC4DD00EB1CA1 /* SoftwareUpdate.hpp */,
 				CEAAA50921FC976100683764 /* RestrictEvents.cpp */,
+				415F010527AB6C21001F0143 /* vnode_types.hpp */,
 			);
 			path = RestrictEvents;
 			sourceTree = "<group>";

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -206,7 +206,7 @@ struct RestrictEventsPolicy {
 	static bool csValidatePageMountainLion(void *blobs, memory_object_kernel_t pager, memory_object_offset_t page_offset, const void *data, int *tainted) {
 		bool result = FunctionCast(csValidatePageMountainLion, orgCsValidateFunc)(blobs, pager, page_offset, data, tainted);
 		if (pager != nullptr && pager->mo_pager_ops == vnodePagerOpsKernel)
-			performReplacements(((vnode_pager_t) pager)->vnode_handle, data, PAGE_SIZE);
+			performReplacements(reinterpret_cast<vnode_pager_t>(pager)->vnode_handle, data, PAGE_SIZE);
 		return result;
 	}
 

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -14,34 +14,7 @@
 #include <Headers/kern_policy.hpp>
 
 #include "SoftwareUpdate.hpp"
-
-//
-// Private definitions from memory_object_types.h and vnode_pager.h
-//
-typedef struct memory_object {
-	unsigned int	_pad1; /* struct ipc_object_header */
-#ifdef __LP64__
-	unsigned int	_pad2; /* pad to natural boundary */
-#endif
-	const void		*mo_pager_ops;
-} *memory_object_kernel_t;
-
-typedef natural_t ipc_object_bits_t;
-
-struct ipc_object_header {
-	ipc_object_bits_t io_bits;
-#ifdef __LP64__
-	natural_t         io_padding; /* pad to natural boundary */
-#endif
-};
-
-typedef struct vnode_pager {
-	struct ipc_object_header	pager_header;	/* fake ip_kotype()		*/
-	void *pager_ops;	/* == &vnode_pager_ops	     */
-	unsigned int		ref_count;	/* reference count	     */
-	memory_object_control_t control_handle;	/* mem object control handle */
-	struct vnode		*vnode_handle;	/* vnode handle 	     */
-} *vnode_pager_t;
+#include "vnode_types.hpp"
 
 extern "C" {
 #include <i386/pmCPU.h>

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -313,7 +313,7 @@ struct RestrictEventsPolicy {
 	 * Retrieve which system UI is to be enabled
 	 */
 	static void processEnableUIPatch() {
-		char duip[128] {};
+		char duip[128] { "auto" };
 		if (PE_parse_boot_argn("revpatch", duip, sizeof(duip))) {
 			DBGLOG("rev", "read revpatch from boot-args");
 		} else if (readNvramVariable(NVRAM_PREFIX(LILU_VENDOR_GUID, "revpatch"), u"revpatch", &EfiRuntimeServices::LiluVendorGuid, duip, sizeof(duip))) {

--- a/RestrictEvents/vnode_types.hpp
+++ b/RestrictEvents/vnode_types.hpp
@@ -1,0 +1,39 @@
+//
+//  vnode_types.hpp
+//  RestrictEvents
+//
+//  Copyright © 2022 vit9696. All rights reserved.
+//
+
+#ifndef vnode_types_h
+#define vnode_types_h
+
+//
+// Private definitions from memory_object_types.h and vnode_pager.h
+//
+typedef struct memory_object {
+	unsigned int	_pad1; /* struct ipc_object_header */
+#ifdef __LP64__
+	unsigned int	_pad2; /* pad to natural boundary */
+#endif
+	const void		*mo_pager_ops;
+} *memory_object_kernel_t;
+
+typedef natural_t ipc_object_bits_t;
+
+struct ipc_object_header {
+	ipc_object_bits_t io_bits;
+#ifdef __LP64__
+	natural_t         io_padding; /* pad to natural boundary */
+#endif
+};
+
+typedef struct vnode_pager {
+	struct ipc_object_header	pager_header;	/* fake ip_kotype()		*/
+	void *pager_ops;	/* == &vnode_pager_ops	     */
+	unsigned int		ref_count;	/* reference count	     */
+	memory_object_control_t control_handle;	/* mem object control handle */
+	struct vnode		*vnode_handle;	/* vnode handle 	     */
+} *vnode_pager_t;
+
+#endif /* vnode_types_h */


### PR DESCRIPTION
See https://github.com/acidanthera/bugtracker/issues/1919.

- [x] 10.9 to 10.11 hooking
- [ ] ~10.8 hooking~
- [x] Patches enabled via options