### PR TITLE
Add support for Process Blocking configuration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@ RestrictEvents Changelog
 - Added additional process blocking:
   - `gmux` - block displaypolicyd on Big Sur+ (for genuine MacBookPro9,1/10,1)
   - `media` - block mediaanalysisd on Ventura+ (for Metal 1 GPUs)
+  - `pci` - block PCIe & memory notifications (for MacPro7,1 SMBIOS)
+    - Previous unconditional
+  - `auto` - same as `pci`, set by default
 
 #### v1.0.8
 - Added constants for macOS 13 support

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,6 @@ RestrictEvents Changelog
 - Added additional process blocking:
   - `gmux` - block displaypolicyd on Big Sur+ (for genuine MacBookPro9,1/10,1)
   - `media` - block mediaanalysisd on Ventura+ (for Metal 1 GPUs)
-  - `telemetry` - block telemetry plugin on Mojave+ (for SSE4,1 CPUs)
 
 #### v1.0.8
 - Added constants for macOS 13 support

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,10 @@ RestrictEvents Changelog
 ========================
 #### v1.0.9
 - Added `revblock` for user configuration of blocking processes
-- Added optional `displaypolicyd` and `mediaanalysisd` blocking
-  - `revblock=gmux` and `revblock=media` options respectively
+- Added additional process blocking:
+  - `gmux` - block displaypolicyd on Big Sur+ (for genuine MacBookPro9,1/10,1)
+  - `media` - block mediaanalysisd on Ventura+ (for Metal 1 GPUs)
+  - `telemetry` - block telemetry plugin on Mojave+ (for SSE4,1 CPUs)
 
 #### v1.0.8
 - Added constants for macOS 13 support

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 RestrictEvents Changelog
 ========================
+#### v1.0.9
+- Added `revblock` for user configuration of blocking processes
+- Added optional `displaypolicyd` and `mediaanalysisd` blocking
+  - `revblock=gmux` and `revblock=media` options respectively
+
 #### v1.0.8
 - Added constants for macOS 13 support
 - Do not enable Memory and PCI UI patching on real Macs in `auto` mode

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ _Note_: Apple CPU identifier must be `0x0F01` for 8 core CPUs or higher and `0x0
   - `pcie` - block ExpansionSlotNotification and MemorySlotNotification on Catalina+ (for MacPro7,1 SMBIOS)
   - `gmux` - block displaypolicyd on Big Sur+ (for genuine MacBookPro9,1/10,1)
   - `media` - block mediaanalysisd on Ventura+ (for Metal 1 GPUs)
-  - `telemetry` - block telemetry plugin on Mojave+ (for SSE4,1 CPUs)
   - `none` - disable all blocking
   - `auto` - same as `pcie`
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ _Note_: Apple CPU identifier must be `0x0F01` for 8 core CPUs or higher and `0x0
 - `revcpu=value` to enable (`1`, non-Intel default)/disable (`0`, Intel default) CPU brand string patching.
 - `revcpuname=value` custom CPU brand string (max 48 characters, 20 or less recommended, taken from CPUID otherwise)
 - `revblock=value` to block processes as comma separated options. Default value is `auto`.
-  - `pcie` - block ExpansionSlotNotification and MemorySlotNotification on Catalina+ (for MacPro7,1 SMBIOS)
+  - `pci` - block ExpansionSlotNotification and MemorySlotNotification on Catalina+ (for MacPro7,1 SMBIOS)
   - `gmux` - block displaypolicyd on Big Sur+ (for genuine MacBookPro9,1/10,1)
   - `media` - block mediaanalysisd on Ventura+ (for Metal 1 GPUs)
   - `none` - disable all blocking
-  - `auto` - same as `pcie`
+  - `auto` - same as `pci`
 
 _Note_: `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revpatch`, `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revcpu`, `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revcpuname` and `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revblock` NVRAM variables work the same as the boot arguments, but have lower priority.
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ _Note_: Apple CPU identifier must be `0x0F01` for 8 core CPUs or higher and `0x0
 - `revcpu=value` to enable (`1`, non-Intel default)/disable (`0`, Intel default) CPU brand string patching.
 - `revcpuname=value` custom CPU brand string (max 48 characters, 20 or less recommended, taken from CPUID otherwise)
 - `revblock=value` to block processes as comma separated options. Default value is `auto`.
-  - `pcie` - block ExpansionSlotNotification and MemorySlotNotification on Catalina+
-  - `gmux` - block displaypolicyd on Big Sur+
-  - `media` - block mediaanalysisd on Ventura+
+  - `pcie` - block ExpansionSlotNotification and MemorySlotNotification on Catalina+ (for MacPro7,1 SMBIOS)
+  - `gmux` - block displaypolicyd on Big Sur+ (for genuine MacBookPro9,1/10,1)
+  - `media` - block mediaanalysisd on Ventura+ (for Metal 1 GPUs)
+  - `telemetry` - block telemetry plugin on Mojave+ (for SSE4,1 CPUs)
   - `none` - disable all blocking
   - `auto` - same as `pcie`
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,15 @@ _Note_: Apple CPU identifier must be `0x0F01` for 8 core CPUs or higher and `0x0
   - `auto` - same as `memtab,pci,cpuname`, without `memtab` and `pci` patches being applied on real Macs
 - `revcpu=value` to enable (`1`, non-Intel default)/disable (`0`, Intel default) CPU brand string patching.
 - `revcpuname=value` custom CPU brand string (max 48 characters, 20 or less recommended, taken from CPUID otherwise)
+- `revblock=value` to block processes as comma separated options. Default value is `auto`.
+  - `pcie` - block ExpansionSlotNotification and MemorySlotNotification on Catalina+
+  - `gmux` - block displaypolicyd on Big Sur+
+  - `media` - block mediaanalysisd on Ventura+
+  - `none` - disable all blocking
+  - `auto` - same as `pcie`
 
-_Note_: `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revpatch`, `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revcpu` and `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revcpuname` NVRAM variables work the same as the boot arguments, but have lower priority.
+_Note_: `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revpatch`, `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revcpu`, `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revcpuname` and `4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:revblock` NVRAM variables work the same as the boot arguments, but have lower priority.
 
 #### Credits
-- [Apple](https://www.apple.com) for macOS  
-- [vit9696](https://github.com/vit9696) for [Lilu.kext](https://github.com/vit9696/Lilu) and great help in implementing some features 
+- [Apple](https://www.apple.com) for macOS
+- [vit9696](https://github.com/vit9696) for [Lilu.kext](https://github.com/vit9696/Lilu) and great help in implementing some features

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -265,11 +265,12 @@ struct RestrictEventsPolicy {
 		char duip[128] { "auto" };
 		if (PE_parse_boot_argn("revblock", duip, sizeof(duip))) {
 			DBGLOG("rev", "read revblock from boot-args");
-		} else if (readNvramVariable(NVRAM_PREFIX(LILU_VENDOR_GUID, "revblock"), u"revblock", &EfiRuntimeServices::LiluVendorGuid, duip, sizeof(duip) - 1)) {
+		} else if (readNvramVariable(NVRAM_PREFIX(LILU_VENDOR_GUID, "revblock"), u"revblock", &EfiRuntimeServices::LiluVendorGuid, duip, sizeof(duip))) {
 			DBGLOG("rev", "read revblock from NVRAM");
 		}
 
 		char *value = reinterpret_cast<char *>(&duip[0]);
+		value[sizeof(duip) - 1] = '\0';
 		size_t i = 0;
 
 		// Disable notification prompts for mismatched memory configuration on MacPro7,1
@@ -343,11 +344,12 @@ struct RestrictEventsPolicy {
 		char duip[128] { "auto" };
 		if (PE_parse_boot_argn("revpatch", duip, sizeof(duip))) {
 			DBGLOG("rev", "read revpatch from boot-args");
-		} else if (readNvramVariable(NVRAM_PREFIX(LILU_VENDOR_GUID, "revpatch"), u"revpatch", &EfiRuntimeServices::LiluVendorGuid, duip, sizeof(duip) - 1)) {
+		} else if (readNvramVariable(NVRAM_PREFIX(LILU_VENDOR_GUID, "revpatch"), u"revpatch", &EfiRuntimeServices::LiluVendorGuid, duip, sizeof(duip))) {
 			DBGLOG("rev", "read revpatch from NVRAM");
 		}
 
 		char *value = reinterpret_cast<char *>(&duip[0]);
+		value[sizeof(duip) - 1] = '\0';
 
 		if (strstr(value, "memtab", strlen("memtab"))) {
 			enableMemoryUiPatching = true;

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -76,7 +76,7 @@ static pmCallBacks_t pmCallbacks;
 static uint8_t findDiskArbitrationPatch[] = { 0x83, 0xF8, 0x02 };
 static uint8_t replDiskArbitrationPatch[] = { 0x83, 0xF8, 0x0F };
 
-char *procBlacklist[10] = {};
+const char *procBlacklist[10] = {};
 
 struct RestrictEventsPolicy {
 
@@ -278,9 +278,8 @@ struct RestrictEventsPolicy {
 			if (strstr(value, "pci", strlen("pci")) || strstr(value, "auto", strlen("auto"))) {
 				if (getKernelVersion() >= KernelVersion::Catalina) {
 					DBGLOG("rev", "disabling PCIe & memory notifications");
-					procBlacklist[i] = (char *)"/System/Library/CoreServices/ExpansionSlotNotification";
-					procBlacklist[i+1] = (char *)"/System/Library/CoreServices/MemorySlotNotification";
-					i += 2;
+					procBlacklist[i++] = (char *)"/System/Library/CoreServices/ExpansionSlotNotification";
+					procBlacklist[i++] = (char *)"/System/Library/CoreServices/MemorySlotNotification";
 				}
 			}
 		}
@@ -289,8 +288,7 @@ struct RestrictEventsPolicy {
 		if (strstr(value, "gmux", strlen("gmux"))) {
 			if (getKernelVersion() >= KernelVersion::BigSur) {
 				DBGLOG("rev", "disabling displaypolicyd");
-				procBlacklist[i] = (char *)"/usr/libexec/displaypolicyd";
-				i++;
+				procBlacklist[i++] = (char *)"/usr/libexec/displaypolicyd";
 			}
 		}
 
@@ -298,8 +296,7 @@ struct RestrictEventsPolicy {
 		if (strstr(value, "media", strlen("media"))) {
 			if (getKernelVersion() >= KernelVersion::Ventura) {
 				DBGLOG("rev", "disabling mediaanalysisd");
-				procBlacklist[i] = (char *)"/System/Library/PrivateFrameworks/MediaAnalysis.framework/Versions/A/mediaanalysisd";
-				i++;
+				procBlacklist[i++] = (char *)"/System/Library/PrivateFrameworks/MediaAnalysis.framework/Versions/A/mediaanalysisd";
 			}
 		}
 

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -301,15 +301,6 @@ struct RestrictEventsPolicy {
 			}
 		}
 
-		// Systems lacking SSE4,2 will crash when telemetry plugin is loaded on Mojave+
-		if (strstr(value, "telemetry", strlen("telemetry"))) {
-			if (getKernelVersion() >= KernelVersion::Mojave) {
-				DBGLOG("rev", "disabling telemetry");
-				procBlacklist[i] = (char *)"/System/Library/UserEventPlugins/com.apple.telemetry.plugin/Contents/MacOS/com.apple.telemetry";
-				i++;
-			}
-		}
-
 		DBGLOG("rev", "blocked %d processes", i);
 		for (auto &proc : procBlacklist) {
 			if (proc == nullptr) break;

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -265,12 +265,11 @@ struct RestrictEventsPolicy {
 		char duip[128] { "auto" };
 		if (PE_parse_boot_argn("revblock", duip, sizeof(duip))) {
 			DBGLOG("rev", "read revblock from boot-args");
-		} else if (readNvramVariable(NVRAM_PREFIX(LILU_VENDOR_GUID, "revblock"), u"revblock", &EfiRuntimeServices::LiluVendorGuid, duip, sizeof(duip))) {
+		} else if (readNvramVariable(NVRAM_PREFIX(LILU_VENDOR_GUID, "revblock"), u"revblock", &EfiRuntimeServices::LiluVendorGuid, duip, sizeof(duip) - 1)) {
 			DBGLOG("rev", "read revblock from NVRAM");
 		}
 
 		char *value = reinterpret_cast<char *>(&duip[0]);
-		value[strlen(duip)] = '\0';
 		size_t i = 0;
 
 		// Disable notification prompts for mismatched memory configuration on MacPro7,1
@@ -344,12 +343,11 @@ struct RestrictEventsPolicy {
 		char duip[128] { "auto" };
 		if (PE_parse_boot_argn("revpatch", duip, sizeof(duip))) {
 			DBGLOG("rev", "read revpatch from boot-args");
-		} else if (readNvramVariable(NVRAM_PREFIX(LILU_VENDOR_GUID, "revpatch"), u"revpatch", &EfiRuntimeServices::LiluVendorGuid, duip, sizeof(duip))) {
+		} else if (readNvramVariable(NVRAM_PREFIX(LILU_VENDOR_GUID, "revpatch"), u"revpatch", &EfiRuntimeServices::LiluVendorGuid, duip, sizeof(duip) - 1)) {
 			DBGLOG("rev", "read revpatch from NVRAM");
 		}
 
 		char *value = reinterpret_cast<char *>(&duip[0]);
-		value[sizeof(duip) - 1] = '\0';
 
 		if (strstr(value, "memtab", strlen("memtab"))) {
 			enableMemoryUiPatching = true;

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -260,7 +260,7 @@ struct RestrictEventsPolicy {
 		return true;
 	}
 
-	static void getBlockedProcesses() {
+	static void getBlockedProcesses(BaseDeviceInfo *info) {
 		// Updates procBlacklist with list of processes to block
 		char duip[128] { "auto" };
 		if (PE_parse_boot_argn("revblock", duip, sizeof(duip))) {
@@ -274,12 +274,14 @@ struct RestrictEventsPolicy {
 		int i = 0;
 
 		// Disable notification prompts for mismatched memory configuration on MacPro7,1
-		if (strstr(value, "pcie", strlen("pcie")) || strstr(value, "auto", strlen("auto"))) {
-			if (getKernelVersion() >= KernelVersion::Catalina) {
-				DBGLOG("rev", "disabling PCIe memory notification");
-				procBlacklist[i] = (char *)"/System/Library/CoreServices/ExpansionSlotNotification";
-				procBlacklist[i+1] = (char *)"/System/Library/CoreServices/MemorySlotNotification";
-				i += 2;
+		if (strcmp(info->modelIdentifier, "MacPro7,1") {
+			if (strstr(value, "pcie", strlen("pcie")) || strstr(value, "auto", strlen("auto"))) {
+				if (getKernelVersion() >= KernelVersion::Catalina) {
+					DBGLOG("rev", "disabling PCIe memory notification");
+					procBlacklist[i] = (char *)"/System/Library/CoreServices/ExpansionSlotNotification";
+					procBlacklist[i+1] = (char *)"/System/Library/CoreServices/MemorySlotNotification";
+					i += 2;
+				}
 			}
 		}
 
@@ -503,7 +505,7 @@ PluginConfiguration ADDPR(config) {
 		DBGLOG("rev", "restriction policy plugin loaded");
 		verboseProcessLogging = checkKernelArgument("-revproc");
 		auto di = BaseDeviceInfo::get();
-		RestrictEventsPolicy::getBlockedProcesses();
+		RestrictEventsPolicy::getBlockedProcesses(&di);
 		RestrictEventsPolicy::processEnableUIPatch(&di);
 		restrictEventsPolicy.policy.registerPolicy();
 		revassetIsSet = enableAssetPatching;

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -271,10 +271,10 @@ struct RestrictEventsPolicy {
 
 		char *value = reinterpret_cast<char *>(&duip[0]);
 		value[sizeof(duip) - 1] = '\0';
-		int i = 0;
+		size_t i = 0;
 
 		// Disable notification prompts for mismatched memory configuration on MacPro7,1
-		if (strcmp(info->modelIdentifier, "MacPro7,1")) {
+		if (strcmp(info->modelIdentifier, "MacPro7,1") == 0) {
 			if (strstr(value, "pci", strlen("pci")) || strstr(value, "auto", strlen("auto"))) {
 				if (getKernelVersion() >= KernelVersion::Catalina) {
 					DBGLOG("rev", "disabling PCIe & memory notifications");

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -272,6 +272,7 @@ struct RestrictEventsPolicy {
 		value[sizeof(duip) - 1] = '\0';
 		int i = 0;
 
+		// Disable notification prompts for mismatched memory configuration on MacPro7,1
 		if (strstr(value, "pcie", strlen("pcie")) || strstr(value, "auto", strlen("auto"))) {
 			if (getKernelVersion() >= KernelVersion::Catalina) {
 				procBlacklist[i] = (char *)"/System/Library/CoreServices/ExpansionSlotNotification";
@@ -292,6 +293,14 @@ struct RestrictEventsPolicy {
 		if (strstr(value, "media", strlen("media"))) {
 			if (getKernelVersion() >= KernelVersion::Ventura) {
 				procBlacklist[i] = (char *)"/System/Library/PrivateFrameworks/MediaAnalysis.framework/Versions/A/mediaanalysisd";
+				i++;
+			}
+		}
+
+		// Systems lacking SSE4,2 will crash when telemetry plugin is loaded on Mojave+
+		if (strstr(value, "telemetry", strlen("telemetry"))) {
+			if (getKernelVersion() >= KernelVersion::Mojave) {
+				procBlacklist[i] = (char *)"/System/Library/UserEventPlugins/com.apple.telemetry.plugin/Contents/MacOS/com.apple.telemetry";
 				i++;
 			}
 		}

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -275,9 +275,9 @@ struct RestrictEventsPolicy {
 
 		// Disable notification prompts for mismatched memory configuration on MacPro7,1
 		if (strcmp(info->modelIdentifier, "MacPro7,1")) {
-			if (strstr(value, "pcie", strlen("pcie")) || strstr(value, "auto", strlen("auto"))) {
+			if (strstr(value, "pci", strlen("pci")) || strstr(value, "auto", strlen("auto"))) {
 				if (getKernelVersion() >= KernelVersion::Catalina) {
-					DBGLOG("rev", "disabling PCIe memory notification");
+					DBGLOG("rev", "disabling PCIe & memory notifications");
 					procBlacklist[i] = (char *)"/System/Library/CoreServices/ExpansionSlotNotification";
 					procBlacklist[i+1] = (char *)"/System/Library/CoreServices/MemorySlotNotification";
 					i += 2;
@@ -303,7 +303,6 @@ struct RestrictEventsPolicy {
 			}
 		}
 
-		DBGLOG("rev", "blocked %d processes", i);
 		for (auto &proc : procBlacklist) {
 			if (proc == nullptr) break;
 			DBGLOG("rev", "blocking %s", proc);

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -270,7 +270,7 @@ struct RestrictEventsPolicy {
 		}
 
 		char *value = reinterpret_cast<char *>(&duip[0]);
-		value[sizeof(duip) - 1] = '\0';
+		value[strlen(duip) - 1] = '\0';
 		size_t i = 0;
 
 		// Disable notification prompts for mismatched memory configuration on MacPro7,1

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -270,7 +270,7 @@ struct RestrictEventsPolicy {
 		}
 
 		char *value = reinterpret_cast<char *>(&duip[0]);
-		value[strlen(duip) - 1] = '\0';
+		value[strlen(duip)] = '\0';
 		size_t i = 0;
 
 		// Disable notification prompts for mismatched memory configuration on MacPro7,1

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -274,7 +274,7 @@ struct RestrictEventsPolicy {
 		int i = 0;
 
 		// Disable notification prompts for mismatched memory configuration on MacPro7,1
-		if (strcmp(info->modelIdentifier, "MacPro7,1") {
+		if (strcmp(info->modelIdentifier, "MacPro7,1")) {
 			if (strstr(value, "pcie", strlen("pcie")) || strstr(value, "auto", strlen("auto"))) {
 				if (getKernelVersion() >= KernelVersion::Catalina) {
 					DBGLOG("rev", "disabling PCIe memory notification");


### PR DESCRIPTION
Adds the following:

* NVRAM variable configuration via `revblock=`
  * `pci` - block ExpansionSlotNotification and MemorySlotNotification on Catalina+
    * Add Catalina limit as genuine MacPro5,1s are supported on Mojave and older
  * `gmux` - block displaypolicyd on Big Sur+
    * Resolves GMUX switching on MacBookPro9,1 and 10,1
  * `media` - block mediaanalysisd on Ventura+
    * Resolves idle panic on Metal 1 GPUs
  * `none` - disable all blocking
  * `auto` - same as `pci`

Logic based off of the previously implemented `revpatch=`