### PR TITLE
Add ContinuityCaptureAgent to media blocklist

### DIFF
--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -297,6 +297,7 @@ struct RestrictEventsPolicy {
 			if (getKernelVersion() >= KernelVersion::Ventura) {
 				DBGLOG("rev", "disabling mediaanalysisd");
 				procBlacklist[i++] = (char *)"/System/Library/PrivateFrameworks/MediaAnalysis.framework/Versions/A/mediaanalysisd";
+				procBlacklist[i++] = (char *)"/usr/libexec/ContinuityCaptureAgent";
 			}
 		}
 

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -293,9 +293,10 @@ struct RestrictEventsPolicy {
 		}
 
 		// Metal 1 GPUs will hard crash when 'mediaanalysisd' is active on Ventura and newer
+		// Metal 1 GPUs do not support Continuity Camera
 		if (strstr(value, "media", strlen("media"))) {
 			if (getKernelVersion() >= KernelVersion::Ventura) {
-				DBGLOG("rev", "disabling mediaanalysisd");
+				DBGLOG("rev", "disabling mediaanalysisd & ContinuityCaptureAgent");
 				procBlacklist[i++] = (char *)"/System/Library/PrivateFrameworks/MediaAnalysis.framework/Versions/A/mediaanalysisd";
 				procBlacklist[i++] = (char *)"/usr/libexec/ContinuityCaptureAgent";
 			}


### PR DESCRIPTION
- Metal 1 GPUs do not support Continuity Camera
- ContinuityCaptureAgent keeps running as a service and causes unneeded CPU load


This is untested. But I am open to test it in a dev build of RestrictEvents.

Request for Comment