### PR TITLE
sysctl hooking: disable F16C reporting on Ivy Bridge

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 RestrictEvents Changelog
 ========================
+#### v1.1.0
+- Added `hw.optional.f16c` disabling for macOS 13.3+
+  - Resolves CoreGraphics.framework invoking AVX2.0 code paths on Ivy Bridge CPUs
+  - Configurable via `revpatch`'s `f16c` argument
+
 #### v1.0.9
 - Added `revblock` for user configuration of blocking processes
 - Added additional process blocking:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ _Note_: Apple CPU identifier must be `0x0F01` for 8 core CPUs or higher and `0x0
   - `diskread` - disables uninitialized disk warning in Finder
   - `asset` - allows Content Caching when `sysctl kern.hv_vmm_present` returns `1` on macOS 11.3 or newer
   - `sbvmm` - forces VMM SB model, allowing OTA updates for unsupported models on macOS 11.3 or newer
+  - `f16c` - resolve CoreGraphics crashing on Ivy Bridge CPUs by disabling f16c instruction set reporting in macOS 13.3 or newer
   - `none` - disable all patching
   - `auto` - same as `memtab,pci,cpuname`, without `memtab` and `pci` patches being applied on real Macs
 - `revcpu=value` to enable (`1`, non-Intel default)/disable (`0`, Intel default) CPU brand string patching.

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -567,7 +567,7 @@ PluginConfiguration ADDPR(config) {
 						rerouteHvVmm(patcher);
 					if ((enableF16cPatching) &&
 						(getKernelVersion() > KernelVersion::Ventura ||
-						 (getKernelVersion() == KernelVersion::Ventura && getKernelMinorVersion() >= 4)))
+						(getKernelVersion() == KernelVersion::Ventura && getKernelMinorVersion() >= 4)))
 						reroutef16c(patcher);
 				});
 			}

--- a/RestrictEvents/RestrictEvents.cpp
+++ b/RestrictEvents/RestrictEvents.cpp
@@ -49,6 +49,7 @@ static bool enableCpuNamePatching;
 static bool enableDiskArbitrationPatching;
 static bool enableAssetPatching;
 static bool enableSbvmmPatching;
+static bool enableF16cPatching;
 
 static bool verboseProcessLogging;
 static mach_vm_address_t orgCsValidateFunc;
@@ -369,6 +370,9 @@ struct RestrictEventsPolicy {
 		if (strstr(value, "sbvmm", strlen("sbvmm"))) {
 			enableSbvmmPatching = true;
 		}
+		if (strstr(value, "f16c", strlen("f16c"))) {
+			enableF16cPatching = true;
+		}
 		if (strstr(value, "auto", strlen("auto"))) {
 			// Do not enable Memory and PCI UI patching on real Macs
 			// Reference: https://github.com/acidanthera/bugtracker/issues/2046
@@ -484,6 +488,7 @@ struct RestrictEventsPolicy {
 static RestrictEventsPolicy restrictEventsPolicy;
 
 void rerouteHvVmm(KernelPatcher &patcher);
+void reroutef16c(KernelPatcher &patcher);
 
 PluginConfiguration ADDPR(config) {
 	xStringify(PRODUCT_NAME),
@@ -560,6 +565,10 @@ PluginConfiguration ADDPR(config) {
 						(getKernelVersion() == KernelVersion::BigSur && getKernelMinorVersion() >= 4)) &&
 						(revsbvmmIsSet || revassetIsSet))
 						rerouteHvVmm(patcher);
+					if ((enableF16cPatching) &&
+						(getKernelVersion() > KernelVersion::Ventura ||
+						 (getKernelVersion() == KernelVersion::Ventura && getKernelMinorVersion() >= 4)))
+						reroutef16c(patcher);
 				});
 			}
 		}

--- a/RestrictEvents/SoftwareUpdate.cpp
+++ b/RestrictEvents/SoftwareUpdate.cpp
@@ -159,7 +159,6 @@ static int my_sysctl_vmm_present(__unused struct sysctl_oid *oidp, __unused void
 	return FunctionCast(my_sysctl_vmm_present, org_sysctl_vmm_present)(oidp, arg1, arg2, req);
 }
 
-static mach_vm_address_t org_sysctl_f16c; // hw.optional.f16c
 static int my_sysctl_f16c(__unused struct sysctl_oid *oidp, __unused void *arg1, int arg2, struct sysctl_req *req) {
 	int f16c_off = 0;
 	return SYSCTL_OUT(req, &f16c_off, sizeof(f16c_off));
@@ -202,8 +201,7 @@ void reroutef16c(KernelPatcher &patcher) {
 		return;
 	}
 	
-	org_sysctl_f16c = patcher.routeFunction(reinterpret_cast<mach_vm_address_t>(f16c->oid_handler), reinterpret_cast<mach_vm_address_t>(my_sysctl_f16c), true);
-	if (!org_sysctl_f16c) {
+	if (!patcher.routeFunction(reinterpret_cast<mach_vm_address_t>(f16c->oid_handler), reinterpret_cast<mach_vm_address_t>(my_sysctl_f16c), true)) {
 		SYSLOG("supd", "failed to route hw.optional.f16c sysctl");
 		patcher.clearError();
 		return;

--- a/RestrictEvents/SoftwareUpdate.cpp
+++ b/RestrictEvents/SoftwareUpdate.cpp
@@ -161,14 +161,8 @@ static int my_sysctl_vmm_present(__unused struct sysctl_oid *oidp, __unused void
 
 static mach_vm_address_t org_sysctl_f16c; // hw.optional.f16c
 static int my_sysctl_f16c(__unused struct sysctl_oid *oidp, __unused void *arg1, int arg2, struct sysctl_req *req) {
-	char procname[64];
-	proc_name(proc_pid(req->p), procname, sizeof(procname));
-	if (strcmp(procname, "com.apple.CoreGraphics") == 0) {
-		int f16c_off = 0;
-		return SYSCTL_OUT(req, &f16c_off, sizeof(f16c_off));
-	}
-
-	return FunctionCast(my_sysctl_f16c, org_sysctl_f16c)(oidp, arg1, arg2, req);
+	int f16c_off = 0;
+	return SYSCTL_OUT(req, &f16c_off, sizeof(f16c_off));
 }
 
 

--- a/RestrictEvents/SoftwareUpdate.cpp
+++ b/RestrictEvents/SoftwareUpdate.cpp
@@ -168,7 +168,7 @@ static int my_sysctl_f16c(__unused struct sysctl_oid *oidp, __unused void *arg1,
 		return SYSCTL_OUT(req, &f16c_off, sizeof(f16c_off));
 	}
 
-	return FunctionCast(my_sysctl_vmm_present, org_sysctl_vmm_present)(oidp, arg1, arg2, req);
+	return FunctionCast(my_sysctl_f16c, org_sysctl_f16c)(oidp, arg1, arg2, req);
 }
 
 


### PR DESCRIPTION
With macOS 13.3 (XNU 22.4), Apple now assumes all CPUs with F16C support AVX2.0 (explicitly [`vpbroadcastw`](https://www.felixcloutier.com/x86/vpbroadcast) within CoreGraphics.frameworks' `resample_horizontal_f16c()`). However Ivy Bridge CPUs only support F16C but lack AVX2.0.

This looks to be flawed logic on Apple’s end due to Rosetta emulating neither F16C or AVX2.0. However as no native Intel Macs in Ventura lack AVX2.0, this bug would likely be ignored.

----------

To resolve, we can hook the `hw.optional.f16c` sysctl entry CoreGraphics.framework checks. However due to CoreGraphics being a library loaded into other processes and not its own distinct process, we cannot target it directly.

Due to Ivy Bridge Macs requiring the use of a Rosetta Cryptex in macOS Ventura, I believe it's safest to assume that f16c is "unsupported" in the x86_64(non-h) dyld shared caches and thus should be disabled on Ivy Bridge CPUs when booting 13.3+