### PR TITLE
SoftwareUpdate.cpp: Expand `sbvmm` to support more environments

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 RestrictEvents Changelog
 ========================
+#### v1.1.3
+- Expanded `sbvmm` to support more environments:
+  - macOS install applications (ex. `Install macOS Sonoma.app`)
+  - Booted installer and recoveryOS
+    - `-no_compat_check` or boot.efi patch required to pass bootloaders' compatibility checks
+
 #### v1.1.2
 - Added constants for macOS 14 support
 

--- a/RestrictEvents/SoftwareUpdate.cpp
+++ b/RestrictEvents/SoftwareUpdate.cpp
@@ -148,7 +148,16 @@ static int my_sysctl_vmm_present(__unused struct sysctl_oid *oidp, __unused void
 	char procname[64];
 	proc_name(proc_pid(req->p), procname, sizeof(procname));
 	// SYSLOG("supd", "\n\n\n\nsoftwareupdated vmm_present %d - >>> %s <<<<\n\n\n\n", arg2, procname);
-	if (revsbvmmIsSet && ((lilu.getRunMode() & LiluAPI::RunningInstallerRecovery) || (strcmp(procname, "softwareupdated") == 0 || strcmp(procname, "com.apple.Mobile") == 0))) {
+	if (revsbvmmIsSet && (
+		// Always return 1 in recovery/installers
+		(lilu.getRunMode() & LiluAPI::RunningInstallerRecovery) ||
+		// Otherwise, check if userspace OS updaters/installers
+		(
+		 strcmp(procname, "softwareupdated") == 0 ||
+		 strcmp(procname, "com.apple.Mobile") == 0 ||
+		 strcmp(procname, "osinstallersetup") == 0    // Primarily for 'Install macOS.app'
+		)
+	)) {
 		int hv_vmm_present_on = 1;
 		return SYSCTL_OUT(req, &hv_vmm_present_on, sizeof(hv_vmm_present_on));
 	} else if (revassetIsSet && (strncmp(procname, "AssetCache",  sizeof("AssetCache")-1) == 0)) {

--- a/RestrictEvents/SoftwareUpdate.cpp
+++ b/RestrictEvents/SoftwareUpdate.cpp
@@ -148,7 +148,7 @@ static int my_sysctl_vmm_present(__unused struct sysctl_oid *oidp, __unused void
 	char procname[64];
 	proc_name(proc_pid(req->p), procname, sizeof(procname));
 	// SYSLOG("supd", "\n\n\n\nsoftwareupdated vmm_present %d - >>> %s <<<<\n\n\n\n", arg2, procname);
-	if (revsbvmmIsSet && (strcmp(procname, "softwareupdated") == 0 || strcmp(procname, "com.apple.Mobile") == 0)) {
+	if (revsbvmmIsSet && ((lilu.getRunMode() & LiluAPI::RunningInstallerRecovery) || (strcmp(procname, "softwareupdated") == 0 || strcmp(procname, "com.apple.Mobile") == 0))) {
 		int hv_vmm_present_on = 1;
 		return SYSCTL_OUT(req, &hv_vmm_present_on, sizeof(hv_vmm_present_on));
 	} else if (revassetIsSet && (strncmp(procname, "AssetCache",  sizeof("AssetCache")-1) == 0)) {

--- a/RestrictEvents/SoftwareUpdate.cpp
+++ b/RestrictEvents/SoftwareUpdate.cpp
@@ -150,7 +150,7 @@ static int my_sysctl_vmm_present(__unused struct sysctl_oid *oidp, __unused void
 	// SYSLOG("supd", "\n\n\n\nsoftwareupdated vmm_present %d - >>> %s <<<<\n\n\n\n", arg2, procname);
 	if (revsbvmmIsSet && (
 		// Always return 1 in recovery/installers
-		(lilu.getRunMode() & LiluAPI::RunningInstallerRecovery) ||
+		(lilu.getRunMode() & LiluAPI::RunningInstallerRecovery != 0) ||
 		// Otherwise, check if userspace OS updaters/installers
 		(
 		 strcmp(procname, "softwareupdated") == 0 ||


### PR DESCRIPTION
Expands support to the following:
- OS Installers (ex. `Install macOS Sonoma.app`)
- Recovery/Installers environment
  - Set unconditionally since name matching is unreliable when Apple uses fused binaries which may not report an expected name (similar to [CryptexFixup.kext with `ramrod`/`UpdateBrainLibrary` patching](https://github.com/acidanthera/CryptexFixup/blob/1.0.2/CryptexFixup/kern_start.cpp#L18-L20))